### PR TITLE
Fix author name in ehatrom Cargo.toml

### DIFF
--- a/ehatrom/Cargo.toml
+++ b/ehatrom/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["raspberry-pi", "eeprom", "hat", "i2c", "crc32"]
 categories = ["embedded", "hardware-support"]
 readme = "README.md"
 license = "MIT"
-authors = ["Alekei Zakharchenko <ehatrom@4stm4.ru>"]
+authors = ["Aleksei Zakharchenko <ehatrom@4stm4.ru>"]
 exclude = [
   "tests/*",
   "Dockerfile*",


### PR DESCRIPTION
## Summary
- correct the spelling of Aleksei Zakharchenko in `ehatrom/Cargo.toml`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684dbc4929b083259654bc63af1cf2ca