### PR TITLE
Fix cross compilation script binary name

### DIFF
--- a/cross_compile.sh
+++ b/cross_compile.sh
@@ -12,7 +12,8 @@ fi
 
 # Variables
 TARGET="armv7-unknown-linux-gnueabihf"
-BINARY_NAME="minimal"
+# Name of the resulting binary matches the package name
+BINARY_NAME="ocultum"
 
 # Build the project
 cargo build --release --target $TARGET


### PR DESCRIPTION
## Summary
- fix binary name in `cross_compile.sh`

## Testing
- `cargo test --quiet`
- `cargo test --quiet` in `ehatrom`

------
https://chatgpt.com/codex/tasks/task_e_684dbad93c588325ac2b3fca6963b4c2