### PR TITLE
Release ehatrom 0.3.0: Update documentation and CHANGELOG

### DIFF
--- a/ehatrom/CHANGELOG.md
+++ b/ehatrom/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.0] — 2025-06-13
+## [0.3.0] — 2025-06-17
 - **BREAKING**: **Bare-Metal Support** - Library now supports `#![no_std]` environments
   - Conditional compilation with feature flags: `alloc`, `std`, `linux`
   - Alternative APIs for no-allocation environments (`serialize_to_slice`, `serialize_to_buffer`)

--- a/ehatrom/README.md
+++ b/ehatrom/README.md
@@ -125,14 +125,14 @@ See also: [update_and_run.md](./update_and_run.md) for usage automation.
 
 ## Command-line interface (CLI)
 
-A full-featured CLI is available starting from version 0.2.0:
+A full-featured CLI is available starting from version 0.3.0:
 
 ```
 Usage: ehatrom <read|write|show|detect> [options]
 
 Commands:
-  read <i2c-dev> <address> <output.bin>   Read EEPROM via I2C and save to file
-  write <i2c-dev> <address> <input.bin>   Write EEPROM from file to I2C device
+  read [i2c-dev] <output.bin>             Read EEPROM via I2C and save to file
+  write [i2c-dev] <input.bin>             Write EEPROM from file to I2C device
   show <input.bin>                        Show parsed EEPROM info from file (debug format)
   detect [i2c-dev]                        Auto-detect HAT EEPROM on specific device (default: /dev/i2c-0)
   detect --all                            Scan all available I2C devices for HAT EEPROM
@@ -141,11 +141,17 @@ Commands:
 Examples:
 
 ```sh
-# Read EEPROM to file
-sudo ehatrom read /dev/i2c-0 0x50 dump.bin
+# Read EEPROM to file (uses default /dev/i2c-0 and address 0x50)
+sudo ehatrom read dump.bin
 
-# Write EEPROM from file
-sudo ehatrom write /dev/i2c-0 0x50 dump.bin
+# Read EEPROM from specific I2C device
+sudo ehatrom read /dev/i2c-1 dump.bin
+
+# Write EEPROM from file (uses default /dev/i2c-0 and address 0x50)
+sudo ehatrom write dump.bin
+
+# Write EEPROM to specific I2C device
+sudo ehatrom write /dev/i2c-1 dump.bin
 
 # Show EEPROM info (debug format)
 ./ehatrom show dump.bin


### PR DESCRIPTION
# Ehatrom v0.3.0

## Breaking Changes
- **Bare-Metal Support** - Library now supports `#![no_std]` environments
  - Conditional compilation with feature flags: `alloc`, `std`, `linux`
  - Alternative APIs for no-allocation environments (`serialize_to_slice`, `serialize_to_buffer`)
  - Static data support for embedded systems (`from_bytes_no_alloc`, `set_custom_atoms`)
  - Custom `EhatromError` type for better no_std error handling
- I2C functions now return `EhatromError` instead of `Box<dyn std::error::Error>`
- **Simplified CLI Interface** - Commands now automatically use HAT EEPROM address (0x50)
  - `read [i2c-dev] <output.bin>` - No longer requires manual address specification
  - `write [i2c-dev] <input.bin>` - No longer requires manual address specification
  - Default I2C device: `/dev/i2c-0` (HAT standard)

## New Features
- Bare-metal example (`examples/bare_metal_example.rs`)
- Cross-platform compatibility with proper `#[cfg]` attributes
- Enhanced CLI with Linux feature detection and better help messages

## Feature Flags
- `default = ["alloc"]` - Standard usage with heap allocation
- `alloc` - Enable Vec/String types (requires alloc crate)
- `std` - Enable full std library features (implies alloc)
- `linux` - Enable I2C device support (requires i2cdev, std)